### PR TITLE
Initial full implementation of ZapPoolLiquidity.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -136,6 +136,7 @@ public:
         consensus.FortCanningRoadHeight = 1786000; // April 11, 2022.
         consensus.FortCanningCrunchHeight = 1936000; // June 2, 2022.
         consensus.FortCanningSpringHeight = 2033000; // July 6, 2022.
+        consensus.ApertureHeight = 2033001; // TODO: update this to a sensible height.
         consensus.GreatWorldHeight = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
@@ -374,6 +375,7 @@ public:
         consensus.FortCanningRoadHeight = 893700;
         consensus.FortCanningCrunchHeight = 1011600;
         consensus.FortCanningSpringHeight = 1086000;
+        consensus.ApertureHeight = 1086001; // TODO: update this to a sensible value.
         consensus.GreatWorldHeight = std::numeric_limits<int>::max();
 
         consensus.pos.diffLimit = uint256S("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
@@ -554,6 +556,7 @@ public:
         consensus.BayfrontHeight = 0;
         consensus.BayfrontMarinaHeight = 0;
         consensus.BayfrontGardensHeight = 0;
+        consensus.ApertureHeight = 0;
         consensus.ClarkeQuayHeight = 0;
         consensus.DakotaHeight = 10;
         consensus.DakotaCrescentHeight = 10;
@@ -739,6 +742,7 @@ public:
         consensus.BayfrontHeight = 10000000;
         consensus.BayfrontMarinaHeight = 10000000;
         consensus.BayfrontGardensHeight = 10000000;
+        consensus.ApertureHeight = 10000000;
         consensus.ClarkeQuayHeight = 10000000;
         consensus.DakotaHeight = 10000000;
         consensus.DakotaCrescentHeight = 10000000;
@@ -960,6 +964,7 @@ void SetupCommonArgActivationParams(Consensus::Params &consensus) {
     UpdateHeightValidation("AMK", "-amkheight", consensus.AMKHeight);
     UpdateHeightValidation("Bayfront", "-bayfrontheight", consensus.BayfrontHeight);
     UpdateHeightValidation("Bayfront Gardens", "-bayfrontgardensheight", consensus.BayfrontGardensHeight);
+    UpdateHeightValidation("Aperture", "-apertureheight", consensus.ApertureHeight);
     UpdateHeightValidation("Clarke Quay", "-clarkequayheight", consensus.ClarkeQuayHeight);
     UpdateHeightValidation("Dakota", "-dakotaheight", consensus.DakotaHeight);
     UpdateHeightValidation("Dakota Crescent", "-dakotacrescentheight", consensus.DakotaCrescentHeight);

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -98,6 +98,7 @@ struct Params {
     int FortCanningCrunchHeight;
     int FortCanningSpringHeight;
     int GreatWorldHeight;
+    int ApertureHeight;
 
     /** Foundation share after AMK, normalized to COIN = 100% */
     CAmount foundationShareDFIP1;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -489,6 +489,7 @@ void SetupServerArgs()
     gArgs.AddArg("-amkheight", "AMK fork activation height (regtest only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-bayfrontheight", "Bayfront fork activation height (regtest only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-bayfrontgardensheight", "Bayfront Gardens fork activation height (regtest only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-apertureheight", "Aperture fork activation height (regtest only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-clarkequayheight", "ClarkeQuay fork activation height (regtest only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-dakotaheight", "Dakota fork activation height (regtest only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-dakotacrescentheight", "DakotaCrescent fork activation height (regtest only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);

--- a/src/masternodes/mn_checks.h
+++ b/src/masternodes/mn_checks.h
@@ -59,6 +59,7 @@ enum class CustomTxType : uint8_t
     PoolSwapV2            = 'i',
     AddPoolLiquidity      = 'l',
     RemovePoolLiquidity   = 'r',
+    ZapPoolLiquidity      = 'Z',
     // accounts
     UtxosToAccount        = 'U',
     AccountToUtxos        = 'b',
@@ -124,6 +125,7 @@ inline CustomTxType CustomTxCodeToType(uint8_t ch) {
         case CustomTxType::PoolSwapV2:
         case CustomTxType::AddPoolLiquidity:
         case CustomTxType::RemovePoolLiquidity:
+        case CustomTxType::ZapPoolLiquidity:
         case CustomTxType::UtxosToAccount:
         case CustomTxType::AccountToUtxos:
         case CustomTxType::AccountToAccount:
@@ -347,6 +349,7 @@ using CCustomTxMessage = std::variant<
     CPoolSwapMessageV2,
     CLiquidityMessage,
     CRemoveLiquidityMessage,
+    CZapLiquidityMessage,
     CUtxosToAccountMessage,
     CAccountToUtxosMessage,
     CAccountToAccountMessage,

--- a/src/masternodes/poolpairs.h
+++ b/src/masternodes/poolpairs.h
@@ -284,6 +284,21 @@ struct CRemoveLiquidityMessage {
     }
 };
 
+struct CZapLiquidityMessage {
+    CAccounts from;
+    DCT_ID poolId;
+    CScript shareAddress;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(from);
+        READWRITE(poolId);
+        READWRITE(shareAddress);
+    }
+};
+
 bool poolInFee(const bool forward, const std::pair<CFeeDir, CFeeDir>& asymmetricFee);
 bool poolOutFee(const bool forward, const std::pair<CFeeDir, CFeeDir>& asymmetricFee);
 

--- a/src/masternodes/rpc_customtx.cpp
+++ b/src/masternodes/rpc_customtx.cpp
@@ -134,6 +134,16 @@ public:
         rpcInfo.pushKV("amount", obj.amount.ToString());
     }
 
+    void operator()(const CZapLiquidityMessage& obj) const {
+        CBalances sumTx = SumAllTransfers(obj.from);
+        if (sumTx.balances.size() == 1) {
+            auto amount = *sumTx.balances.begin();
+            rpcInfo.pushKV(amount.first.ToString(), ValueFromAmount(amount.second));
+            rpcInfo.pushKV("poolid", obj.poolId.ToString());
+            rpcInfo.pushKV("shareaddress", ScriptToString(obj.shareAddress));
+        }
+    }
+
     void operator()(const CUtxosToAccountMessage& obj) const {
         rpcInfo.pushKVs(accountsInfo(obj.to));
     }

--- a/test/functional/feature_poolpair_liquidity.py
+++ b/test/functional/feature_poolpair_liquidity.py
@@ -29,10 +29,10 @@ class PoolLiquidityTest (DefiTestFramework):
         # node2: revert create (all)
         self.setup_clean_chain = True
         self.extra_args = [
-            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50'],
-            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50'],
-            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50'],
-            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50']]
+            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-apertureheight=50'],
+            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-apertureheight=50'],
+            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-apertureheight=50'],
+            ['-txnotokens=0', '-amkheight=50', '-bayfrontheight=50', '-apertureheight=50']]
 
     def run_test(self):
         assert_equal(len(self.nodes[0].listtokens()), 1) # only one token == DFI
@@ -187,6 +187,21 @@ class PoolLiquidityTest (DefiTestFramework):
         assert_equal(pool['1']['reserveA'], 150)
         assert_equal(pool['1']['reserveB'], 500)
         assert_equal(pool['1']['totalLiquidity'], 150)
+
+        # Zap liquidity
+        #========================
+        print("Testing zappoolliquidity")
+
+        # more than one token.
+        try:
+            self.nodes[0].zappoolliquidity({
+                accountGold: ["2@" + symbolGOLD, "3@" + symbolSILVER]
+            }, "1", accountGold, [])
+        except JSONRPCException as e:
+            errorString = e.error['message']
+        assert("liquidity zapping requires a single input token" in errorString)
+
+        # TODO(Aperture): Add more test cases.
 
         # Remove liquidity
         #========================


### PR DESCRIPTION
Add and implement a new liquidity pool tx type called "zap liquidity".  See Zapper's [definition](https://learn.zapper.fi/articles/what-is-a-zap) of "zap".

For example, if a user wants to zap liquidity into the DTSLA-DUSD pool.  ZapPoolLiquidity works in the following way:
1. Takes a certain amount of DFI as the input token.
2. Swap all input DFI tokens for DUSD.
3. Optimally swap a portion of DUSD for DTSLA, and provide the obtained DTSLA along with the remaining DUSD tokens as liquidity to the DTSLA-DUSD pool.
All three steps are done in a single tx.

Code is preliminarily complete; functional test in progress.